### PR TITLE
Fix: Re-exporting types for newer Deno versions.

### DIFF
--- a/mod.ts
+++ b/mod.ts
@@ -44,4 +44,5 @@ export function err<T>(error: T): Result<T> {
   return new Err<T>(error);
 }
 
-export { Result, Err, Opt, Some, None };
+export { Err, None, Ok, Some };
+export type { Opt, Result };


### PR DESCRIPTION
Unfortunately the project won't work in newer Deno versions. Since Deno 1.4.0 re-exported types have to be explicit with `export type {}`. Otherwise TS will throw errors.

